### PR TITLE
Handle large EPUB data via object URLs

### DIFF
--- a/src/pages/Reader.jsx
+++ b/src/pages/Reader.jsx
@@ -16,6 +16,7 @@ export default function Reader() {
   const [selection, setSelection] = useState(null)
   const [activeHighlight, setActiveHighlight] = useState(null)
   const [fontSize, setFontSize] = useState(100)
+  const [bookUrl, setBookUrl] = useState(null)
 
   useEffect(() => {
     if (!book) navigate('/')
@@ -89,7 +90,27 @@ export default function Reader() {
     if (rendition) rendition.themes.fontSize(`${newSize}%`)
   }
 
-  if (!book) return null
+  useEffect(() => {
+    let objectUrl
+    async function prepareBook() {
+      try {
+        const res = await fetch(book.file)
+        const blob = await res.blob()
+        objectUrl = URL.createObjectURL(blob)
+        setBookUrl(objectUrl)
+      } catch (e) {
+        console.error('Failed to load book', e)
+      }
+    }
+    if (book?.file) {
+      prepareBook()
+    }
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [book?.file])
+
+  if (!book || !bookUrl) return null
 
   return (
     <div className="reader-view">
@@ -108,7 +129,7 @@ export default function Reader() {
         </div>
         <div className="reader">
           <ReactReader
-            url={book.file}
+            url={bookUrl}
             location={location}
             locationChanged={onLocationChanged}
             getRendition={(r) => setRendition(r)}


### PR DESCRIPTION
## Summary
- Convert stored EPUB data URLs into Blob-based object URLs before loading in `ReactReader`
- Use generated object URL in reader to avoid oversized request headers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b94285dccc8320b0526382c6acd4da